### PR TITLE
Fix interface name in configuration of authentication adapter

### DIFF
--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -17,7 +17,7 @@ As an example of configuration:
 ```php
 // config/autoload/authentication.global.php
 
-use Mezzio\Authentication\AdapterInterface;
+use Mezzio\Authentication\AuthenticationInterface;
 use Mezzio\Authentication\Basic\BasicAccess;
 use Mezzio\Authentication\UserRepositoryInterface;
 use Mezzio\Authentication\UserRepository\PdoDatabase;
@@ -31,7 +31,7 @@ return [
 
             // Tell mezzio-authentication to use the BasicAccess
             // adapter:
-            AdapterInterface::class => BasicAccess::class,
+            AuthenticationInterface::class => BasicAccess::class,
         ],
     ],
     'authentication' => [


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

The documented class `Mezzio\Authentication\AdapterInterface` does not exist. `Mezzio\Authentication\AuthenticationInterface` is the correct reference.