### PR TITLE
Fixes example of protecting an entire sub-path

### DIFF
--- a/docs/book/v1/usage.md
+++ b/docs/book/v1/usage.md
@@ -24,9 +24,7 @@ authentication, use [path-segregation](https://docs.laminas.dev/laminas-stratigi
 use Mezzio\Authentication\AuthenticationMiddleware;
 
 // In the callback:
-$app->pipe('/api', $factory->path(
-    $factory->prepare(AuthenticationMiddleware::class)
-));
+$app->pipe('/api', AuthenticationMiddleware::class);
 ```
 
 ## For a specific route


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

This PR fixes the usage example of protecting an entire sub-path by

- removing the call to an undefined method `Mezzio\MiddlewareFactory#prepare` and
- removing the unnecessary call to `Mezzio\MiddlewareFactory#prepare` which is redundant, since `Mezzio\Authentication\AuthenticationMiddleware` implements `Psr\Http\Server\MiddlewareInterface`
